### PR TITLE
User salting enabled

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,8 +28,9 @@ gem 'jquery-rails'
 
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
+
 # Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
     arel (9.0.0)
     autoprefixer-rails (9.6.0)
       execjs
+    bcrypt (3.1.13)
     bindex (0.7.0)
     bootsnap (1.4.4)
       msgpack (~> 1.0)
@@ -256,6 +257,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
   bootstrap
   byebug

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,15 @@ class User < ApplicationRecord
 
   def initialize(*args)
     args.first[:email] = args.first[:email].downcase
-    # TODO 6.17.2019: Salt Passwords on Creation:
+
+    # generate and add salt to model arguemns
+    salt = SecureRandom.hex(32)
+    args.first[:salt] = salt
+
+    # create new salted and hashed password
+    password = BCrypt::Password.create(salt + args.first[:password]).to_s
+    args.first[:password] = password
+
     super(*args)
   end
 
@@ -20,8 +28,7 @@ class User < ApplicationRecord
     @spotify_user ||= RSpotify::User.new(spotify_hash)
   end
 
-  # TODO 6.4.2019: add salt hashing
   def authenticate(given_password)
-    given_password == self.password
+    BCrypt::Password.new(self.password) == self.salt + given_password
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,12 +4,12 @@ class User < ApplicationRecord
   def initialize(*args)
     args.first[:email] = args.first[:email].downcase
 
-    # generate and add salt to model arguemns
-    salt = SecureRandom.hex(32)
+    # generate and add salt to model arguments
+    salt = BCrypt::Engine.generate_salt
     args.first[:salt] = salt
 
     # create new salted and hashed password
-    password = BCrypt::Password.create(salt + args.first[:password]).to_s
+    password = BCrypt::Engine.hash_secret(args.first[:password], salt)
     args.first[:password] = password
 
     super(*args)
@@ -29,6 +29,6 @@ class User < ApplicationRecord
   end
 
   def authenticate(given_password)
-    BCrypt::Password.new(self.password) == self.salt + given_password
+    BCrypt::Engine.hash_secret(given_password, self.salt) == self.password
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,60 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @password = "Test$1234"
+    spu_user = RSpotify::User.new({
+      "birthdate"=>nil,
+      "country"=>"US",
+      "display_name"=>"Test Boi",
+      "email"=>"TestBoi@test.com",
+      "followers"=>{"href"=>nil, "total"=>29},
+      "images"=>
+        [{"height"=>nil,
+          "url"=>nil,
+         "width"=>nil}],
+      "product"=>"premium",
+      "external_urls"=>{"spotify"=>"https://open.spotify.com/user/sometestid"},
+      "href"=>"https://api.spotify.com/v1/users/sometestid",
+      "id"=>"sometestid",
+      "type"=>"user",
+      "uri"=>"spotify:user:sometestid",
+      "credentials"=>
+      {"token"=>
+       "testokenid",
+       "refresh_token"=>"testrefreshtokenid",
+       "expires_at"=>1560976502,
+       "expires"=>true}})
+
+    @user = User.create(
+      email: "Test@test.com",
+      password: @password,
+      spotify_hash: spu_user)
+  end
+
+  test "should salt passwords" do
+    refute_equal @password, @user.password
+  end
+
+  test "should authenticate when given correct password" do
+    assert @user.authenticate(@password)
+  end
+
+  test "should not authenticate when givien similar passwords" do
+    refute @user.authenticate(@password.upcase)
+    refute @user.authenticate(@password.downcase)
+    refute @user.authenticate("a" + @password)
+    refute @user.authenticate(@password +"a")
+  end
+
+  test "should build spotify from stored user" do
+    spu = @user.spotify_user
+
+    assert_equal RSpotify::User,     spu.class
+    assert_equal "testokenid",       spu.credentials["token"]
+    assert_equal "TestBoi@test.com", spu.email
+  end
+
+  # TODO 6.19.2019: Add spotify hash tests once the change is made
+
 end


### PR DESCRIPTION
enables the bcrypt gem

adds salt and hashing to user password creation and authentication
user tests.