### PR TITLE
update spotify_hash methods

### DIFF
--- a/app/controllers/spotify_controller.rb
+++ b/app/controllers/spotify_controller.rb
@@ -11,8 +11,9 @@ class SpotifyController < ApplicationController
     @req = request.env['omniauth.auth']
     @playlists = @spotify_user.playlists
 
-    if session[:current_user].present?
-      session[:current_user].spotify_hash = @spotify_user
+    if current_user.present?
+      current_user.spotify_user = @spotify_user
+      current_user.save!
     end
   end
 

--- a/app/controllers/spotify_controller.rb
+++ b/app/controllers/spotify_controller.rb
@@ -18,6 +18,7 @@ class SpotifyController < ApplicationController
   end
 
   def user_playlists
+    @user_playlists = current_user.playlists
   end
 
   def playlist

--- a/app/controllers/spotify_controller.rb
+++ b/app/controllers/spotify_controller.rb
@@ -13,6 +13,7 @@ class SpotifyController < ApplicationController
 
     if current_user.present?
       current_user.spotify_user = @spotify_user
+      current_user.activated = true
       current_user.save!
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,17 +15,17 @@ class User < ApplicationRecord
     super(*args)
   end
 
-  def spotify_hash=(spotify_user)
+  def spotify_user
+    @spotify_user ||= RSpotify::User.new(spotify_hash)
+  end
+
+  def spotify_user=(spotify_user)
     spu_json = spotify_user.to_hash.to_json
-    super(spu_json)
+    self.spotify_hash = spu_json
   end
 
   def spotify_hash
     JSON.parse(self[:spotify_hash])
-  end
-
-  def spotify_user
-    @spotify_user ||= RSpotify::User.new(spotify_hash)
   end
 
   def authenticate(given_password)

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,6 +4,6 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :spotify,
   ENV['SPOTIFY_CLIENT_ID'],
   ENV['SPOTIFY_CLIENT_SECRET'],
-  scope: 'user-read-private user-read-email'
+  scope: 'user-read-private user-read-email playlist-modify-public playlist-modify-private'
 end
 

--- a/lib/spotify/spotify.rb
+++ b/lib/spotify/spotify.rb
@@ -37,7 +37,29 @@ module Spotify::Spotify
   def add_tracks_to_playlist(tracks, playlist)
   end
 
+  def re_auth_user!(user)
+    raise ArgumentError("User must be an active record model, not spotify user") if !user.is_a?(User)
+    spotify_user = user.spotify_user
+    refresh_token = spotify_user.credentials["refresh_token"]
+    spotify_user.credentials["token"] = refresh_access_token(refresh_token)
+    user.spotify_user = spotify_user
+
+    user.save!
+  end
+
   private
+
+  def refresh_access_token(refresh_token)
+    response = Faraday.post(
+      'https://accounts.spotify.com/api/token',
+      {
+        'client_id' => CLIENT_ID,
+        'client_secret' => CLIENT_SECRET,
+        'grant_type' => 'refresh_token',
+        'refresh_token' => refresh_token })
+
+    acess_token = JSON.parse(response.body)["access_token"]
+  end
 
   # returns an array of requested type resource objects for a given object
   # ex: resources_for_object(album, :tracks) => returns [Array<Tracks>]

--- a/lib/spotify/spotify.rb
+++ b/lib/spotify/spotify.rb
@@ -37,8 +37,12 @@ module Spotify::Spotify
   def add_tracks_to_playlist(tracks, playlist)
   end
 
+  # updates a user objects spotify hash with a new acces token
+  # @param user [ActiveRecord::User]
+  # @return [Boolean] true if user is saved, false otherwise
   def re_auth_user!(user)
     raise ArgumentError("User must be an active record model, not spotify user") if !user.is_a?(User)
+
     spotify_user = user.spotify_user
     refresh_token = spotify_user.credentials["refresh_token"]
     spotify_user.credentials["token"] = refresh_access_token(refresh_token)
@@ -49,6 +53,9 @@ module Spotify::Spotify
 
   private
 
+  # requests a refresh for users access token
+  # @param refresh_token [String] a users spotify refresh token
+  # @return [String] a users spotify access token
   def refresh_access_token(refresh_token)
     response = Faraday.post(
       'https://accounts.spotify.com/api/token',

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -29,7 +29,7 @@ class UserTest < ActiveSupport::TestCase
     @user = User.create(
       email: "Test@test.com",
       password: @password,
-      spotify_hash: spu_user)
+      spotify_user: spu_user)
   end
 
   test "should salt passwords" do
@@ -54,7 +54,4 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "testokenid",       spu.credentials["token"]
     assert_equal "TestBoi@test.com", spu.email
   end
-
-  # TODO 6.19.2019: Add spotify hash tests once the change is made
-
 end


### PR DESCRIPTION
updates the usage of the spotify hash

additionally adds a re-auth method that is not yet implemented