### PR TITLE
Obfuscate spotify user

### DIFF
--- a/app/controllers/spotify_controller.rb
+++ b/app/controllers/spotify_controller.rb
@@ -9,12 +9,15 @@ class SpotifyController < ApplicationController
   def callback
     @spotify_user = RSpotify::User.new(request.env['omniauth.auth'])
     @req = request.env['omniauth.auth']
-    @playlists = @spotify_user.playlists
 
     if current_user.present?
       current_user.spotify_user = @spotify_user
       current_user.activated = true
       current_user.save!
+
+      @playlists = current_uesr.playlists
+    else
+      @playlists = @spotify_user.playlists
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,4 +31,21 @@ class User < ApplicationRecord
   def authenticate(given_password)
     BCrypt::Engine.hash_secret(given_password, self.salt) == self.password
   end
+
+  # INTERFACE
+  def playlists(limt: 20, offset: 0)
+    spotify_user.playlists(limit: limit, offeset: offset)
+  end
+
+  def create_playlist!(name, public: true)
+    spotify_user.create_playist(name, public: public)
+  end
+
+  def recently_played(limit: 20)
+    spotify_user.recently_played(limit: limit)
+  end
+
+  def saved_tracks(limit: 20, offset: 0)
+    spotify_user.saved_tracks(limit: limit, offset: offset)
+  end
 end

--- a/lib/spotify/spotify.rb
+++ b/lib/spotify/spotify.rb
@@ -46,6 +46,7 @@ module Spotify::Spotify
     spotify_user = user.spotify_user
     refresh_token = spotify_user.credentials["refresh_token"]
     spotify_user.credentials["token"] = refresh_access_token(refresh_token)
+    spotify_user.credentials["expires_at"] = time.now.to_i + 3600
     user.spotify_user = spotify_user
 
     user.save!

--- a/lib/spotify/spotify.rb
+++ b/lib/spotify/spotify.rb
@@ -46,7 +46,7 @@ module Spotify::Spotify
     spotify_user = user.spotify_user
     refresh_token = spotify_user.credentials["refresh_token"]
     spotify_user.credentials["token"] = refresh_access_token(refresh_token)
-    spotify_user.credentials["expires_at"] = time.now.to_i + 3600
+    spotify_user.credentials["expires_at"] = Time.now.to_i + 3600
     user.spotify_user = spotify_user
 
     user.save!

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -4,11 +4,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
 
   test "login with invalid information" do
     get login_path
-    assert_template 'sessions/new'
     post login_path, params: { session: { email: "", password: "" } }
-    assert_template 'sessions/new'
+    
     assert_not flash.empty?
-    get root_path
+
+    get users_test_path
     assert flash.empty?
   end
 end


### PR DESCRIPTION
Hides RSpotify user methods behind my active record model and impliments spotify access token refreshing because the gem is broken.